### PR TITLE
Add live neutral mode override

### DIFF
--- a/sdk/HIDMaestro.Core/HMController.cs
+++ b/sdk/HIDMaestro.Core/HMController.cs
@@ -71,6 +71,14 @@ public sealed class HMController : IDisposable
     // Sized at HidReportBuilder.InputReportByteSize, computed in the ctor.
     private readonly byte[] _reportBuffer;
 
+    // Canonical per-profile neutral state. Do not use default(HMGamepadState)
+    // as "neutral": many real controller descriptors use unsigned stick axes
+    // (0..255 or 0..65535) where descriptor zero means full-left/up, not
+    // center. Build this once so Neutralized can substitute a correct idle
+    // frame on every profile.
+    private readonly HMGamepadState _neutralState;
+    private HMGamepadState _lastSubmittedState;
+
     // v1.3.0 — per-controller reusable raw report buffer. SubmitRawReport
     // (DualSense / vendor-protocol path) used to do report.ToArray() per
     // call; this 64-byte buffer absorbs the copy without the alloc churn.
@@ -131,6 +139,14 @@ public sealed class HMController : IDisposable
     // descriptor-driven BuildReportInto path so consumers that never issue
     // the handshake still see legacy Report 1 emission.
     private volatile bool _extendedModeArmed;
+
+    // Neutral-input override. When true, every frame submitted through
+    // SubmitState / SubmitRawReport is replaced with a blank neutral frame
+    // before it reaches shared memory, so games / XInput / WGI see no active
+    // input even though the consumer keeps pushing the real gamepad's data.
+    // The device stays present and "connected" (no PnP teardown), so the flag
+    // can be flipped on and off live without reconnecting the controller.
+    private volatile bool _neutralized;
 
     /// <summary>Optional diagnostic: invoked at the end of every successful
     /// <see cref="SubmitState"/> with the elapsed microseconds. Wire this
@@ -306,6 +322,7 @@ public sealed class HMController : IDisposable
         // re-parsing the descriptor on every ctor.
         _reportBuilder = profile.Inner.GetOrBuildReportBuilder();
         _reportBuffer = new byte[_reportBuilder.InputReportByteSize];
+        _neutralState = BuildNeutralState(profile, _reportBuilder);
 
         // Only profiles with an XUSB companion (HMXInput.dll) read the
         // GIP-format buffer slice on IOCTL_XUSB_GET_STATE. xinputhid-bound
@@ -353,22 +370,121 @@ public sealed class HMController : IDisposable
         }
     }
 
+    private static HMGamepadState BuildNeutralState(HMProfile profile, HidReportBuilder reportBuilder)
+    {
+        var axes = new Dictionary<HMAxis, float>();
+
+        // Generic axis fallback: signed centered axes idle at 0.5; unsigned
+        // non-role axes (throttles, pedals, sliders) idle/release at 0.0.
+        foreach (var (axis, field) in reportBuilder.AxisFields)
+        {
+            if (axis != HMAxis.None)
+                axes[axis] = field.LogicalMin < 0 ? 0.5f : 0.0f;
+        }
+
+        // Role-aware override: sticks are neutral at center even when the
+        // descriptor uses unsigned logical ranges (DS4/DS5/Switch Pro).
+        foreach (var stick in profile.Sticks)
+        {
+            if (stick.XAxis != HMAxis.None) axes[stick.XAxis] = 0.5f;
+            if (stick.YAxis != HMAxis.None) axes[stick.YAxis] = 0.5f;
+        }
+
+        // Triggers/pedals are released at zero.
+        foreach (var trigger in profile.Triggers)
+        {
+            if (trigger.Axis != HMAxis.None) axes[trigger.Axis] = 0.0f;
+        }
+
+        return new HMGamepadState
+        {
+            Axes = axes,
+            Buttons = HMButton.None,
+            Hat = HMHat.None,
+        };
+    }
+
+    /// <summary>Neutral-input override. When set to <c>true</c>, every frame
+    /// the consumer submits through <see cref="SubmitState"/> /
+    /// <see cref="SubmitRawReport"/> is discarded and replaced with a blank
+    /// neutral frame (sticks centered, triggers released, no buttons, hat
+    /// neutral) before it is written to shared memory. As a result games,
+    /// XInput, and WGI see the controller as present and connected but
+    /// completely idle — regardless of what the real input source is doing.
+    ///
+    /// <para>Flipping this flag does <b>not</b> reconnect or remove the
+    /// device: the virtual controller stays enumerated and "on" the whole
+    /// time. Setting it to <c>true</c> immediately publishes one neutral
+    /// frame so any input currently held on the consumer side is released
+    /// right away, without waiting for the consumer's next submit.</para>
+    ///
+    /// <para>Thread-safe to set from any thread (the field is volatile and
+    /// the submit path reads it once per frame).</para></summary>
+    public bool Neutralized
+    {
+        get => _neutralized;
+        set
+        {
+            bool wasNeutral = _neutralized;
+            _neutralized = value;
+            // On the rising edge, push a neutral frame now so the device goes
+            // idle instantly instead of holding the consumer's last frame
+            // until its next SubmitState call.
+            if (value && !wasNeutral && !_disposed)
+            {
+                try
+                {
+                    SubmitStateCore(in _neutralState, rememberSourceState: false);
+                }
+                catch { /* best-effort: a transient write failure here is non-fatal */ }
+            }
+            else if (!value && wasNeutral && !_disposed)
+            {
+                try
+                {
+                    SubmitStateCore(in _lastSubmittedState, rememberSourceState: false);
+                }
+                catch { /* best-effort: the consumer's next SubmitState will refresh input */ }
+            }
+        }
+    }
+
     /// <summary>Push the next input frame to the virtual controller.
     /// The SDK encodes <paramref name="state"/> into the active profile's
-    /// HID report layout and publishes it via shared memory.</summary>
+    /// HID report layout and publishes it via shared memory.
+    ///
+    /// <para>While <see cref="Neutralized"/> is <c>true</c> the submitted
+    /// frame is ignored and a neutral frame is published instead.</para></summary>
     public void SubmitState(in HMGamepadState state)
+        => SubmitStateCore(in state, rememberSourceState: true);
+
+    private void SubmitStateCore(in HMGamepadState state, bool rememberSourceState)
     {
         ThrowIfDisposed();
 
         long startTicks = OnSubmitLatencyMicros != null
             ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
+        // Remember the latest source state even while neutralized. When the
+        // flag is turned off, we can immediately republish this state instead
+        // of leaving the virtual stuck on the neutral frame until the source
+        // happens to submit again.
+        if (rememberSourceState)
+            _lastSubmittedState = state;
+
+        // Neutral-input override: substitute the per-profile neutral frame for
+        // the caller's data. Sticks must be explicitly centered for unsigned
+        // descriptors (DS4/DS5/Switch Pro), while triggers/buttons/hat stay
+        // released. Everything downstream (HID report, GIP/XInput buffer,
+        // vendor-blob codec) then encodes an idle controller.
+        HMGamepadState effective = _neutralized ? _neutralState : state;
+
         // v1.3.9 — single unified state.Axes dict drives every analog input.
         // Resolve the 6 "simple-slot" values (left stick X/Y, right stick
         // X/Y, LT, RT) by looking up each profile's declared sticks/triggers
         // in the axes dict. Auto-default: 0.5 (centered) for sticks, 0.0
         // (released) for triggers.
-        var axes = state.Axes;
+        var axes = effective.Axes;
         double GetAxis(HMAxis ax, double def) =>
             axes != null && axes.TryGetValue(ax, out var v) ? Math.Clamp(v, 0f, 1f) : def;
 
@@ -424,7 +540,7 @@ public sealed class HMController : IDisposable
             // The driver-side WriteToInputReport recognizes the extended
             // path via the SHARED_INPUT.ExtendedReportSize > 0 hint set
             // alongside the legacy bytes below.
-            VendorBlobCodec.EncodeInput(Profile.ExtendedReport!, in state,
+            VendorBlobCodec.EncodeInput(Profile.ExtendedReport!, in effective,
                 (float)mlx, (float)mly, (float)mrx, (float)mry, (float)mlt, (float)mrt,
                 _extendedReportBuffer!, _extEncoderState!);
             report = _extendedReportBuffer!;
@@ -435,12 +551,12 @@ public sealed class HMController : IDisposable
             // Hat priority chain (HatDegrees > HatHundredths > HatRaw > Hat)
             // picks the first non-null and ignores the rest.
             _reportBuilder.BuildReportInto(_reportBuffer,
-                axes: state.Axes,
-                hatValue: (int)state.Hat,
-                buttonMask: (uint)state.Buttons,
-                hatDegrees: state.HatDegrees,
-                hatHundredths: state.HatHundredths,
-                hatRaw: state.HatRaw);
+                axes: effective.Axes,
+                hatValue: (int)effective.Hat,
+                buttonMask: (uint)effective.Buttons,
+                hatDegrees: effective.HatDegrees,
+                hatHundredths: effective.HatHundredths,
+                hatRaw: effective.HatRaw);
 
             // v1.3.5 — overlay profile-declared fixed bytes (e.g. DS5 Edge
             // USB activeProfile = 0x80 at byte 49 so dualsense-tester's
@@ -485,7 +601,7 @@ public sealed class HMController : IDisposable
             _gipBuf[8]  = (byte)(gipLt & 0xFF); _gipBuf[9]  = (byte)(gipLt >> 8);
             _gipBuf[10] = (byte)(gipRt & 0xFF); _gipBuf[11] = (byte)(gipRt >> 8);
             // Button low byte: A,B,X,Y,LB,RB,LS,RS (XInput XUSB convention)
-            uint b = (uint)state.Buttons;
+            uint b = (uint)effective.Buttons;
             byte btnLow = 0;
             if ((b & (uint)HMButton.A)           != 0) btnLow |= 0x01;
             if ((b & (uint)HMButton.B)           != 0) btnLow |= 0x02;
@@ -512,7 +628,7 @@ public sealed class HMController : IDisposable
             byte btnHigh = 0;
             if ((b & (uint)HMButton.Back)  != 0) btnHigh |= 0x01;
             if ((b & (uint)HMButton.Start) != 0) btnHigh |= 0x02;
-            btnHigh |= (byte)(((byte)state.Hat & 0x0F) << 2);
+            btnHigh |= (byte)(((byte)effective.Hat & 0x0F) << 2);
             if ((b & (uint)HMButton.Guide) != 0) btnHigh |= 0x40;
             _gipBuf[13] = btnHigh;
         }
@@ -586,6 +702,17 @@ public sealed class HMController : IDisposable
     {
         ThrowIfDisposed();
         if (report.Length == 0) throw new ArgumentException("Report cannot be empty.", nameof(report));
+
+        // Neutral-input override: ignore the raw vendor payload (which can
+        // carry sticks/buttons/gyro/touchpad) and publish a neutral frame via
+        // the structured path instead, so games see an idle controller. We
+        // route through SubmitState so the descriptor-driven neutral report
+        // (and zeroed GIP/XInput buffer) is what reaches the kernel.
+        if (_neutralized)
+        {
+            SubmitStateCore(in _neutralState, rememberSourceState: false);
+            return;
+        }
         if (report.Length > SharedMemoryIO.DATA_CAPACITY)
             throw new ArgumentException(
                 $"Report length {report.Length} exceeds the {SharedMemoryIO.DATA_CAPACITY}-byte shared section payload.",

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -212,6 +212,10 @@ class Program
         // start the circle.
         bool startPaused = profileIds.Contains("--paused-at-zero");
         bool startMarked = profileIds.Contains("--mark");
+        // --neutral: bring every controller up already neutralized. The
+        // pattern thread still runs, but the SDK discards its frames and
+        // publishes neutral input until 'neutral off' is sent over stdin.
+        bool startNeutral = profileIds.Contains("--neutral");
         // --rate-hz N : override the per-virtual SubmitState rate (default 250 Hz,
         // which comes from the pattern thread's Thread.Sleep(4)). PadForge polls
         // at 1 kHz; issue #3 uses 1 kHz and 125 Hz for saturation-rate tests.
@@ -240,9 +244,9 @@ class Program
                 continue;
             }
         }
-        profileIds = profileIds.Where(p => p != "--paused-at-zero" && p != "--mark").ToArray();
+        profileIds = profileIds.Where(p => p != "--paused-at-zero" && p != "--mark" && p != "--neutral").ToArray();
         if (profileIds.Length == 0)
-            return Error("Usage: HIDMaestroTest emulate [--paused-at-zero] [--mark] [--rate-hz N] [--profile-dir <path>]... <profile-id> [profile-id ...]");
+            return Error("Usage: HIDMaestroTest emulate [--paused-at-zero] [--mark] [--neutral] [--rate-hz N] [--profile-dir <path>]... <profile-id> [profile-id ...]");
         // Under HIDMAESTRO_QUIET=1 (regression battery), the stdout pipe is
         // not drained by the harness between Send-Cmd calls. Per-controller
         // setup output (Loaded N profiles / Creating controller / ->created
@@ -308,6 +312,15 @@ class Program
             Console.WriteLine($"  --mark: marked {slots.Count} controller(s) — each holds button=its index");
         }
 
+        // --neutral: start every controller in neutral mode. The device is
+        // fully created and visible to games; it just emits neutral input
+        // until 'neutral off' is sent.
+        if (startNeutral)
+        {
+            foreach (var s in slots) s.Ctrl.Neutralized = true;
+            Console.WriteLine($"  --neutral: {slots.Count} controller(s) start neutralized (send 'neutral off' to pass input through)");
+        }
+
         Console.WriteLine($"\n  All {slots.Count} controller(s) ready.\n");
 
         // Phase 2: input threads — one test-pattern thread per controller.
@@ -325,6 +338,7 @@ class Program
         Console.WriteLine("    resume                        resume submitting input frames");
         Console.WriteLine("    mark                          static frame: each ctrl holds button = its index (browser-order test)");
         Console.WriteLine("    unmark                        leave mark mode and resume the time-varying pattern");
+        Console.WriteLine("    neutral [on|off|toggle] [idx|all]  force neutral output (device stays on, sends no input)");
         Console.WriteLine("    park <idx|all> <x> <y>        pin slot N's left stick to literal x,y in [-1..+1]");
         Console.WriteLine("    park off                      leave park mode and resume the time-varying pattern");
         Console.WriteLine("    remove <index>                dispose a single controller (others stay live)");
@@ -459,6 +473,65 @@ class Program
             {
                 foreach (var s in slots) s.MarkButton = -1;
                 Console.WriteLine($"  unmarked {slots.Count} controller(s) — back to time-varying pattern");
+                continue;
+            }
+            // neutral [on|off|toggle] [idx|all]
+            //   Force the virtual controller(s) to emit neutral input (sticks
+            //   centered, triggers released, no buttons) while staying present
+            //   and "connected". The pattern thread keeps submitting the
+            //   time-varying circle, but the SDK discards it and publishes a
+            //   neutral frame — so this is a live demonstration that the flag
+            //   neutralizes whatever the input source is doing, with no
+            //   reconnect. Default action = toggle, default target = all.
+            if (line.StartsWith("neutral", StringComparison.OrdinalIgnoreCase)
+                && (line.Length == 7 || line[7] == ' '))
+            {
+                var sub = line.Substring(7).Trim()
+                    .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                // Parse optional action keyword and optional target.
+                string action = "toggle";
+                string target = "all";
+                int ti = 0;
+                if (sub.Length > ti && (sub[ti].Equals("on", StringComparison.OrdinalIgnoreCase)
+                                     || sub[ti].Equals("off", StringComparison.OrdinalIgnoreCase)
+                                     || sub[ti].Equals("toggle", StringComparison.OrdinalIgnoreCase)))
+                {
+                    action = sub[ti].ToLowerInvariant();
+                    ti++;
+                }
+                if (sub.Length > ti) target = sub[ti];
+
+                // Resolve target slots.
+                var targets = new List<int>();
+                if (target.Equals("all", StringComparison.OrdinalIgnoreCase))
+                {
+                    for (int i = 0; i < slots.Count; i++)
+                        if (slots[i].Ctrl != null!) targets.Add(i);
+                }
+                else if (int.TryParse(target, out int ni) && ni >= 0 && ni < slots.Count)
+                {
+                    if (slots[ni].Ctrl != null!) targets.Add(ni);
+                    else Console.WriteLine($"  ! neutral: slot {ni} is removed");
+                }
+                else
+                {
+                    Console.WriteLine($"  ! neutral usage: neutral [on|off|toggle] [idx|all]");
+                    continue;
+                }
+
+                foreach (int i in targets)
+                {
+                    var ctrl = slots[i].Ctrl;
+                    bool want = action switch
+                    {
+                        "on"  => true,
+                        "off" => false,
+                        _     => !ctrl.Neutralized,   // toggle
+                    };
+                    ctrl.Neutralized = want;
+                    Console.WriteLine($"  slot {i}: neutral = {(want ? "ON  (device stays connected, sending neutral input)" : "OFF (passing input through)")}");
+                }
                 continue;
             }
             // park <idx> <x> <y>     pin slot N's left stick to literal x,y in [-1..+1]

--- a/test/probes/browser_neutral_check/BrowserNeutralCheck.csproj
+++ b/test/probes/browser_neutral_check/BrowserNeutralCheck.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+</Project>

--- a/test/probes/browser_neutral_check/Program.cs
+++ b/test/probes/browser_neutral_check/Program.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+
+internal sealed class Program
+{
+    private const int Port = 18739;
+    private static string? s_resultJson;
+
+    private sealed class Emu : IDisposable
+    {
+        public Process Proc = default!;
+        public ConcurrentQueue<string> Lines = new();
+
+        public static Emu Start(string testExe)
+        {
+            var emu = new Emu();
+            var psi = new ProcessStartInfo
+            {
+                FileName = testExe,
+                Arguments = "emulate --neutral dualshock-4-v2",
+                WorkingDirectory = Path.GetDirectoryName(testExe)!,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            emu.Proc = new Process { StartInfo = psi };
+            emu.Proc.OutputDataReceived += (_, e) => { if (e.Data != null) emu.Lines.Enqueue(e.Data); };
+            emu.Proc.ErrorDataReceived += (_, e) => { if (e.Data != null) emu.Lines.Enqueue("[stderr] " + e.Data); };
+            if (!emu.Proc.Start()) throw new Exception("failed to start HIDMaestroTest");
+            emu.Proc.BeginOutputReadLine();
+            emu.Proc.BeginErrorReadLine();
+            return emu;
+        }
+
+        public void WaitReady()
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < 30_000)
+            {
+                while (Lines.TryDequeue(out var line))
+                {
+                    Console.WriteLine("  [emu] " + line);
+                    if (line.Contains("controller(s) ready")) return;
+                }
+                if (Proc.HasExited) throw new Exception("HIDMaestroTest exited early: " + Proc.ExitCode);
+                Thread.Sleep(50);
+            }
+            throw new TimeoutException("HIDMaestroTest did not become ready");
+        }
+
+        public void Send(string command)
+        {
+            Console.WriteLine("  [stdin] " + command);
+            Proc.StandardInput.WriteLine(command);
+            Proc.StandardInput.Flush();
+
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < 20_000)
+            {
+                while (Lines.TryDequeue(out var line))
+                {
+                    Console.WriteLine("  [emu] " + line);
+                    if (line.Trim() == "[ACK]") return;
+                }
+                if (Proc.HasExited) throw new Exception("HIDMaestroTest exited while waiting for ACK");
+                Thread.Sleep(50);
+            }
+            throw new TimeoutException("timed out waiting for ACK after " + command);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (!Proc.HasExited)
+                {
+                    try { Proc.StandardInput.WriteLine("quit"); Proc.StandardInput.Flush(); } catch { }
+                    if (!Proc.WaitForExit(60_000)) Proc.Kill(entireProcessTree: true);
+                }
+            }
+            catch { }
+            finally { Proc.Dispose(); }
+        }
+    }
+
+    private static string Html => """
+<!doctype html>
+<html><head><meta charset="utf-8"><title>HM browser neutral check</title></head>
+<body>
+<pre id="out">sampling...</pre>
+<script>
+const samples = [];
+function snap() {
+  const pads = [];
+  for (const p of navigator.getGamepads()) {
+    if (!p) continue;
+    pads.push({
+      index: p.index,
+      id: p.id,
+      connected: p.connected,
+      mapping: p.mapping,
+      timestamp: p.timestamp,
+      axes: Array.from(p.axes),
+      buttons: p.buttons.map(b => ({ pressed: b.pressed, value: b.value }))
+    });
+  }
+  samples.push({ t: performance.now(), pads });
+  document.getElementById('out').textContent = JSON.stringify(pads, null, 2);
+  if (samples.length < 40) setTimeout(snap, 100);
+  else fetch('/result', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ samples, finalSnapshot: samples[samples.length - 1].pads }) })
+    .finally(() => document.title = 'DONE');
+}
+setTimeout(snap, 250);
+</script>
+</body></html>
+""";
+
+    private static HttpListener StartServer()
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{Port}/");
+        listener.Start();
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            while (listener.IsListening)
+            {
+                try
+                {
+                    var ctx = listener.GetContext();
+                    if (ctx.Request.HttpMethod == "POST" && ctx.Request.Url?.AbsolutePath == "/result")
+                    {
+                        using var sr = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
+                        s_resultJson = sr.ReadToEnd();
+                        byte[] ok = Encoding.UTF8.GetBytes("ok");
+                        ctx.Response.OutputStream.Write(ok);
+                        ctx.Response.Close();
+                    }
+                    else
+                    {
+                        byte[] data = Encoding.UTF8.GetBytes(Html);
+                        ctx.Response.ContentType = "text/html; charset=utf-8";
+                        ctx.Response.OutputStream.Write(data);
+                        ctx.Response.Close();
+                    }
+                }
+                catch { break; }
+            }
+        });
+        return listener;
+    }
+
+    private static string FindBrowser()
+    {
+        string[] candidates =
+        {
+            @"C:\Users\Arthur\AppData\Local\imput\Helium\Application\chrome.exe",
+            Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\imput\Helium\Application\helium.exe"),
+            Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\imput\Helium\Application\chrome.exe"),
+            Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\imput\Helium\Application\msedge.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Microsoft\Edge\Application\msedge.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Google\Chrome\Application\chrome.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles(x86)%\Google\Chrome\Application\chrome.exe"),
+        };
+        return candidates.FirstOrDefault(File.Exists) ?? throw new FileNotFoundException("Edge/Chrome not found");
+    }
+
+    [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    private static Process StartBrowser()
+    {
+        string browser = FindBrowser();
+        string profile = Path.Combine(Path.GetTempPath(), "hm_browser_neutral_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(profile);
+        var psi = new ProcessStartInfo
+        {
+            FileName = browser,
+            Arguments = $"--app=http://127.0.0.1:{Port}/ --user-data-dir=\"{profile}\" --no-first-run --no-default-browser-check --disable-background-timer-throttling --disable-renderer-backgrounding --disable-backgrounding-occluded-windows --window-size=500,400 --window-position=100,100",
+            UseShellExecute = false,
+        };
+        var p = Process.Start(psi) ?? throw new Exception("failed to start browser");
+        Thread.Sleep(2500);
+        try
+        {
+            p.Refresh();
+            if (p.MainWindowHandle != IntPtr.Zero)
+            {
+                ShowWindow(p.MainWindowHandle, 5);
+                SetForegroundWindow(p.MainWindowHandle);
+            }
+        }
+        catch { }
+        return p;
+    }
+
+    private static string ResolveTestExe()
+    {
+        string tfm = "net10.0-windows10.0.26100.0";
+        string baseDir = AppContext.BaseDirectory;
+        return Path.GetFullPath(Path.Combine(baseDir,
+            "..", "..", "..", "..", "..", "..",
+            "bin", "Release", tfm, "win-x64", "HIDMaestroTest.exe"));
+    }
+
+    private static JsonElement? FindDs4(JsonElement snapshot)
+    {
+        foreach (var pad in snapshot.EnumerateArray())
+        {
+            string id = pad.GetProperty("id").GetString()?.ToLowerInvariant() ?? "";
+            if ((id.Contains("054c") && id.Contains("09cc")) || id.Contains("wireless controller"))
+                return pad;
+        }
+        return null;
+    }
+
+    private static JsonElement? RunBrowserSample()
+    {
+        s_resultJson = null;
+        using var browser = StartBrowser();
+        var sw = Stopwatch.StartNew();
+        while (s_resultJson == null && sw.ElapsedMilliseconds < 30_000)
+            Thread.Sleep(100);
+        try { browser.Kill(entireProcessTree: true); } catch { }
+        if (s_resultJson == null) return null;
+        return JsonDocument.Parse(s_resultJson).RootElement.Clone();
+    }
+
+    private static List<string> NeutralErrors(JsonElement pad, string prefix)
+    {
+        var errors = new List<string>();
+        int i = 0;
+        foreach (var axis in pad.GetProperty("axes").EnumerateArray())
+        {
+            double v = axis.GetDouble();
+            if (Math.Abs(v) > 0.08) errors.Add($"{prefix}: axis[{i}]={v:F5}");
+            i++;
+        }
+        i = 0;
+        foreach (var b in pad.GetProperty("buttons").EnumerateArray())
+        {
+            double v = b.GetProperty("value").GetDouble();
+            bool pressed = b.GetProperty("pressed").GetBoolean();
+            if (v > 0.08 || pressed) errors.Add($"{prefix}: button[{i}] value={v:F2} pressed={pressed}");
+            i++;
+        }
+        return errors;
+    }
+
+    private static int Main()
+    {
+        Console.WriteLine("=== Browser neutral DS4 check ===");
+        string testExe = ResolveTestExe();
+        Console.WriteLine("HIDMaestroTest: " + testExe);
+        if (!File.Exists(testExe)) { Console.WriteLine("FAIL: HIDMaestroTest not found"); return 2; }
+
+        using var server = StartServer();
+        using var emu = Emu.Start(testExe);
+        try
+        {
+            emu.WaitReady();
+            Thread.Sleep(1000);
+
+            var root = RunBrowserSample();
+            if (root == null)
+            {
+                Console.WriteLine("FAIL: browser did not post gamepad result");
+                return 2;
+            }
+
+            var snapshot = root.Value.GetProperty("finalSnapshot");
+            var ds4 = FindDs4(snapshot);
+            if (ds4 == null)
+            {
+                Console.WriteLine("FAIL: DS4 not found in browser snapshot");
+                Console.WriteLine(root.Value.ToString());
+                return 1;
+            }
+
+            Console.WriteLine("Neutral DS4: " + ds4.Value.GetProperty("id").GetString());
+            var errors = new List<string>();
+            int i = 0;
+            foreach (var axis in ds4.Value.GetProperty("axes").EnumerateArray())
+            {
+                double v = axis.GetDouble();
+                Console.WriteLine($"  axis[{i}]={v:F5}");
+                if (Math.Abs(v) > 0.08) errors.Add($"axis[{i}]={v:F5}");
+                i++;
+            }
+            i = 0;
+            foreach (var b in ds4.Value.GetProperty("buttons").EnumerateArray())
+            {
+                double v = b.GetProperty("value").GetDouble();
+                bool pressed = b.GetProperty("pressed").GetBoolean();
+                if (v > 0.001 || pressed) Console.WriteLine($"  button[{i}] value={v:F2} pressed={pressed}");
+                if (v > 0.08 || pressed) errors.Add($"button[{i}] value={v:F2} pressed={pressed}");
+                i++;
+            }
+
+            int sampleIndex = 0;
+            foreach (var sample in root.Value.GetProperty("samples").EnumerateArray())
+            {
+                var samplePad = FindDs4(sample.GetProperty("pads"));
+                if (samplePad != null)
+                    errors.AddRange(NeutralErrors(samplePad.Value, $"sample[{sampleIndex}]"));
+                sampleIndex++;
+            }
+
+            if (errors.Count > 0)
+            {
+                Console.WriteLine("FAIL: browser sees non-neutral DS4 while neutral is ON:");
+                foreach (var e in errors) Console.WriteLine("  " + e);
+                return 1;
+            }
+
+            Console.WriteLine($"PASS: browser sees neutral DS4 across {sampleIndex} samples");
+
+            emu.Send("neutral off all");
+            Thread.Sleep(500);
+            root = RunBrowserSample();
+            if (root == null)
+            {
+                Console.WriteLine("FAIL: browser did not post gamepad result after neutral off");
+                return 2;
+            }
+            snapshot = root.Value.GetProperty("finalSnapshot");
+            ds4 = FindDs4(snapshot);
+            if (ds4 == null)
+            {
+                Console.WriteLine("FAIL: DS4 not found after neutral off");
+                return 1;
+            }
+
+            var activeErrors = NeutralErrors(ds4.Value, "neutral-off final");
+            Console.WriteLine("Neutral OFF final active fields:");
+            foreach (var e in activeErrors.Take(12)) Console.WriteLine("  " + e);
+            if (activeErrors.Count == 0)
+            {
+                Console.WriteLine("FAIL: neutral off did not expose HIDMaestroTest active pattern");
+                return 1;
+            }
+
+            Console.WriteLine("PASS: neutral off exposes HIDMaestroTest active pattern (expected for emulate)");
+            return 0;
+        }
+        finally
+        {
+            try { server.Stop(); } catch { }
+        }
+    }
+}

--- a/test/probes/browser_neutral_check/app.manifest
+++ b/test/probes/browser_neutral_check/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/test/probes/neutral_cli_check/NeutralCliCheck.csproj
+++ b/test/probes/neutral_cli_check/NeutralCliCheck.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+</Project>

--- a/test/probes/neutral_cli_check/Program.cs
+++ b/test/probes/neutral_cli_check/Program.cs
@@ -1,0 +1,282 @@
+// End-to-end CLI neutral-input override check.
+//
+// Runs HIDMaestroTest.exe emulate, sends the interactive command
+// "neutral on/off/toggle" through stdin, waits for the app's [ACK], and reads
+// XInput externally. This verifies the user-facing CLI path, not just the SDK
+// property.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+internal sealed class Program
+{
+    private const uint ERROR_SUCCESS = 0;
+    private static int s_total;
+    private static int s_failures;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_GAMEPAD
+    {
+        public ushort wButtons;
+        public byte bLeftTrigger;
+        public byte bRightTrigger;
+        public short sThumbLX;
+        public short sThumbLY;
+        public short sThumbRX;
+        public short sThumbRY;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_STATE
+    {
+        public uint dwPacketNumber;
+        public XINPUT_GAMEPAD Gamepad;
+    }
+
+    [DllImport("xinput1_4.dll")]
+    private static extern uint XInputGetState(uint dwUserIndex, out XINPUT_STATE pState);
+
+    private static void Check(string label, bool ok, string detail = "")
+    {
+        s_total++;
+        if (!ok) s_failures++;
+        Console.WriteLine($"  [{(ok ? "PASS" : "FAIL")}] {label}{(detail.Length > 0 ? "  " + detail : "")}");
+    }
+
+    private static string FormatState(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return $"pkt={s.dwPacketNumber} btn=0x{g.wButtons:X4} LT={g.bLeftTrigger} RT={g.bRightTrigger} " +
+               $"LX={g.sThumbLX} LY={g.sThumbLY} RX={g.sThumbRX} RY={g.sThumbRY}";
+    }
+
+    private static HashSet<int> ConnectedSlots()
+    {
+        var result = new HashSet<int>();
+        for (uint i = 0; i < 4; i++)
+            if (XInputGetState(i, out _) == ERROR_SUCCESS) result.Add((int)i);
+        return result;
+    }
+
+    private static int WaitForNewSlot(HashSet<int> baseline, int timeoutMs)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            for (uint i = 0; i < 4; i++)
+            {
+                if (baseline.Contains((int)i)) continue;
+                if (XInputGetState(i, out _) == ERROR_SUCCESS) return (int)i;
+            }
+            Thread.Sleep(50);
+        }
+        return -1;
+    }
+
+    private static bool IsNeutral(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return g.wButtons == 0
+            && g.bLeftTrigger == 0
+            && g.bRightTrigger == 0
+            && Math.Abs((int)g.sThumbLX) <= 2
+            && Math.Abs((int)g.sThumbLY) <= 2
+            && Math.Abs((int)g.sThumbRX) <= 2
+            && Math.Abs((int)g.sThumbRY) <= 2;
+    }
+
+    private static bool IsActive(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return g.wButtons != 0
+            || g.bLeftTrigger > 8
+            || g.bRightTrigger > 8
+            || Math.Abs((int)g.sThumbLX) > 4000
+            || Math.Abs((int)g.sThumbLY) > 4000
+            || Math.Abs((int)g.sThumbRX) > 4000
+            || Math.Abs((int)g.sThumbRY) > 4000;
+    }
+
+    private static bool WaitForActive(int slot, string label, int timeoutMs)
+    {
+        var sw = Stopwatch.StartNew();
+        XINPUT_STATE last = default;
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (XInputGetState((uint)slot, out last) == ERROR_SUCCESS && IsActive(in last))
+            {
+                Check(label, true, FormatState(in last));
+                return true;
+            }
+            Thread.Sleep(80);
+        }
+        Check(label, false, $"last={FormatState(in last)}");
+        return false;
+    }
+
+    private static bool AssertNeutralStable(int slot, string label, int durationMs)
+    {
+        var sw = Stopwatch.StartNew();
+        int samples = 0;
+        XINPUT_STATE last = default;
+        while (sw.ElapsedMilliseconds < durationMs)
+        {
+            samples++;
+            if (XInputGetState((uint)slot, out last) != ERROR_SUCCESS || !IsNeutral(in last))
+            {
+                Check(label, false, $"sample={samples} state={FormatState(in last)}");
+                return false;
+            }
+            Thread.Sleep(60);
+        }
+        Check(label, true, $"{samples} neutral samples; last={FormatState(in last)}");
+        return true;
+    }
+
+    private sealed class EmulateProcess : IDisposable
+    {
+        public required Process Process { get; init; }
+        public required ConcurrentQueue<string> Output { get; init; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (!Process.HasExited)
+                {
+                    try { Send("quit", 30_000); } catch { }
+                    if (!Process.WaitForExit(60_000))
+                    {
+                        Process.Kill(entireProcessTree: true);
+                        Process.WaitForExit(5_000);
+                    }
+                }
+            }
+            finally
+            {
+                Process.Dispose();
+            }
+        }
+
+        public void Send(string command, int timeoutMs)
+        {
+            if (Process.HasExited)
+                throw new InvalidOperationException($"Cannot send '{command}': process exited {Process.ExitCode}");
+
+            Console.WriteLine($"  [stdin] {command}");
+            Process.StandardInput.WriteLine(command);
+            Process.StandardInput.Flush();
+
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < timeoutMs)
+            {
+                while (Output.TryDequeue(out var line))
+                {
+                    if (line.Trim() == "[ACK]") return;
+                }
+                if (Process.HasExited) return;
+                Thread.Sleep(50);
+            }
+            throw new TimeoutException($"Timed out waiting for [ACK] after '{command}'");
+        }
+    }
+
+    private static EmulateProcess StartEmulate(string exe, params string[] args)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = exe,
+            Arguments = "emulate " + string.Join(" ", args),
+            WorkingDirectory = Path.GetDirectoryName(exe)!,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var output = new ConcurrentQueue<string>();
+        var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) output.Enqueue(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) output.Enqueue("[stderr] " + e.Data); };
+        if (!proc.Start()) throw new InvalidOperationException("failed to start HIDMaestroTest");
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        Console.WriteLine($"  started pid={proc.Id}: {psi.FileName} {psi.Arguments}");
+        return new EmulateProcess { Process = proc, Output = output };
+    }
+
+    private static string ResolveTestExe(string[] args)
+    {
+        if (args.Length > 0) return Path.GetFullPath(args[0]);
+
+        string baseDir = AppContext.BaseDirectory;
+        string tfm = "net10.0-windows10.0.26100.0";
+        return Path.GetFullPath(Path.Combine(baseDir,
+            "..", "..", "..", "..", "..", "..",
+            "bin", "Release", tfm, "win-x64", "HIDMaestroTest.exe"));
+    }
+
+    private static int Main(string[] args)
+    {
+        Console.WriteLine("=== HIDMaestro neutral-input CLI regression ===");
+        string testExe = ResolveTestExe(args);
+        Console.WriteLine($"  HIDMaestroTest: {testExe}");
+        if (!File.Exists(testExe))
+        {
+            Console.WriteLine("  FAIL: HIDMaestroTest.exe not found. Build test/HIDMaestroTest.csproj first.");
+            return 2;
+        }
+
+        RunProcess(testExe, "cleanup");
+        Thread.Sleep(500);
+        var baseline = ConnectedSlots();
+        Console.WriteLine($"  baseline XInput slots: {(baseline.Count == 0 ? "(none)" : string.Join(",", baseline))}");
+
+        using (var emu = StartEmulate(testExe, "--rate-hz", "100", "xbox-360-wired"))
+        {
+            int slot = WaitForNewSlot(baseline, timeoutMs: 20_000);
+            if (slot < 0)
+            {
+                Check("virtual claims a new XInput slot", false);
+                return 1;
+            }
+            Check("virtual claims a new XInput slot", true, $"slot={slot}");
+
+            WaitForActive(slot, "startup pattern is active", timeoutMs: 6_000);
+
+            emu.Send("neutral on all", 20_000);
+            AssertNeutralStable(slot, "CLI neutral on keeps slot connected and idle", durationMs: 1_800);
+
+            emu.Send("neutral off all", 20_000);
+            WaitForActive(slot, "CLI neutral off restores active input", timeoutMs: 6_000);
+
+            emu.Send("neutral toggle all", 20_000);
+            AssertNeutralStable(slot, "CLI neutral toggle enables neutral", durationMs: 1_200);
+
+            emu.Send("neutral toggle all", 20_000);
+            WaitForActive(slot, "CLI neutral toggle disables neutral", timeoutMs: 6_000);
+        }
+
+        Console.WriteLine($"\n=== {s_total - s_failures}/{s_total} PASS ===");
+        return s_failures == 0 ? 0 : 1;
+    }
+
+    private static void RunProcess(string exe, string arguments)
+    {
+        using var proc = Process.Start(new ProcessStartInfo
+        {
+            FileName = exe,
+            Arguments = arguments,
+            WorkingDirectory = Path.GetDirectoryName(exe)!,
+            UseShellExecute = false,
+        }) ?? throw new InvalidOperationException($"failed to start {exe}");
+        proc.WaitForExit();
+        if (proc.ExitCode != 0)
+            throw new InvalidOperationException($"{Path.GetFileName(exe)} {arguments} exited {proc.ExitCode}");
+    }
+}

--- a/test/probes/neutral_cli_check/app.manifest
+++ b/test/probes/neutral_cli_check/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/test/probes/neutral_xinput_check/NeutralXInputCheck.csproj
+++ b/test/probes/neutral_xinput_check/NeutralXInputCheck.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk\HIDMaestro.Core\HIDMaestro.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/probes/neutral_xinput_check/Program.cs
+++ b/test/probes/neutral_xinput_check/Program.cs
@@ -1,0 +1,218 @@
+// End-to-end neutral-input override check.
+//
+// Creates a real xbox-360-wired virtual controller, drives an intentionally
+// active HMGamepadState, reads the resulting XInput slot, then enables
+// HMController.Neutralized while continuing to submit that active state. The
+// assertion is intentionally external: XInput must keep reporting the slot as
+// connected, but every input field must stay neutral.
+//
+// Requires admin (driver install + virtual creation). Exit 0 on PASS.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using HIDMaestro;
+
+internal sealed class Program
+{
+    private const uint ERROR_SUCCESS = 0;
+    private static int s_total;
+    private static int s_failures;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_GAMEPAD
+    {
+        public ushort wButtons;
+        public byte bLeftTrigger;
+        public byte bRightTrigger;
+        public short sThumbLX;
+        public short sThumbLY;
+        public short sThumbRX;
+        public short sThumbRY;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_STATE
+    {
+        public uint dwPacketNumber;
+        public XINPUT_GAMEPAD Gamepad;
+    }
+
+    [DllImport("xinput1_4.dll")]
+    private static extern uint XInputGetState(uint dwUserIndex, out XINPUT_STATE pState);
+
+    private static void Check(string label, bool ok, string detail = "")
+    {
+        s_total++;
+        if (!ok) s_failures++;
+        Console.WriteLine($"  [{(ok ? "PASS" : "FAIL")}] {label}{(detail.Length > 0 ? "  " + detail : "")}");
+    }
+
+    private static string FormatState(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return $"pkt={s.dwPacketNumber} btn=0x{g.wButtons:X4} LT={g.bLeftTrigger} RT={g.bRightTrigger} " +
+               $"LX={g.sThumbLX} LY={g.sThumbLY} RX={g.sThumbRX} RY={g.sThumbRY}";
+    }
+
+    private static HashSet<int> ConnectedSlots()
+    {
+        var result = new HashSet<int>();
+        for (uint i = 0; i < 4; i++)
+            if (XInputGetState(i, out _) == ERROR_SUCCESS) result.Add((int)i);
+        return result;
+    }
+
+    private static int WaitForNewSlot(HashSet<int> baseline, int timeoutMs)
+    {
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            for (uint i = 0; i < 4; i++)
+            {
+                if (baseline.Contains((int)i)) continue;
+                if (XInputGetState(i, out _) == ERROR_SUCCESS) return (int)i;
+            }
+            Thread.Sleep(20);
+        }
+        return -1;
+    }
+
+    private static bool IsNeutral(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return g.wButtons == 0
+            && g.bLeftTrigger == 0
+            && g.bRightTrigger == 0
+            // The SDK packs neutral stick centers as 32767/32768-ish and the
+            // XUSB companion maps that back to signed XInput space. Allow a
+            // tiny one/two-count rounding tolerance around zero.
+            && Math.Abs((int)g.sThumbLX) <= 2
+            && Math.Abs((int)g.sThumbLY) <= 2
+            && Math.Abs((int)g.sThumbRX) <= 2
+            && Math.Abs((int)g.sThumbRY) <= 2;
+    }
+
+    private static bool IsActive(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return g.wButtons != 0
+            || g.bLeftTrigger > 8
+            || g.bRightTrigger > 8
+            || Math.Abs((int)g.sThumbLX) > 4000
+            || Math.Abs((int)g.sThumbLY) > 4000
+            || Math.Abs((int)g.sThumbRX) > 4000
+            || Math.Abs((int)g.sThumbRY) > 4000;
+    }
+
+    private static bool WaitForActive(HMController ctrl, in HMGamepadState active, int slot, string label, int timeoutMs)
+    {
+        var sw = Stopwatch.StartNew();
+        XINPUT_STATE last = default;
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            ctrl.SubmitState(in active);
+            Thread.Sleep(30);
+            if (XInputGetState((uint)slot, out last) == ERROR_SUCCESS && IsActive(in last))
+            {
+                Check(label, true, FormatState(in last));
+                return true;
+            }
+        }
+        Check(label, false, $"last={FormatState(in last)}");
+        return false;
+    }
+
+    private static bool AssertNeutralStable(HMController ctrl, in HMGamepadState sourceStillActive, int slot, string label, int durationMs)
+    {
+        var sw = Stopwatch.StartNew();
+        int samples = 0;
+        XINPUT_STATE last = default;
+        while (sw.ElapsedMilliseconds < durationMs)
+        {
+            // Keep submitting active source data while neutralized. This is the
+            // behavior the fork needs for real gamepad passthrough: the source
+            // may still be held/moving, but the virtual output must stay idle.
+            ctrl.SubmitState(in sourceStillActive);
+            Thread.Sleep(30);
+            samples++;
+            if (XInputGetState((uint)slot, out last) != ERROR_SUCCESS || !IsNeutral(in last))
+            {
+                Check(label, false, $"sample={samples} state={FormatState(in last)}");
+                return false;
+            }
+        }
+        Check(label, true, $"{samples} neutral samples; last={FormatState(in last)}");
+        return true;
+    }
+
+    public static int Main()
+    {
+        Console.WriteLine("=== HIDMaestro neutral-input XInput regression ===");
+
+        try { HMContext.RemoveAllVirtualControllers(); } catch { }
+        Thread.Sleep(500);
+        var baseline = ConnectedSlots();
+        Console.WriteLine($"  baseline XInput slots: {(baseline.Count == 0 ? "(none)" : string.Join(",", baseline))}");
+
+        using var ctx = new HMContext();
+        ctx.LoadDefaultProfiles();
+
+        Console.Write("  Installing driver... ");
+        ctx.InstallDriver();
+        Console.WriteLine("OK");
+
+        var profile = ctx.GetProfile("xbox-360-wired")
+                      ?? throw new Exception("missing xbox-360-wired");
+
+        Console.Write("  Creating xbox-360-wired controller... ");
+        using var ctrl = ctx.CreateController(profile);
+        Console.WriteLine("OK");
+
+        int slot = WaitForNewSlot(baseline, timeoutMs: 5000);
+        if (slot < 0)
+        {
+            Console.WriteLine("  FAIL: virtual did not claim a new XInput slot within 5 s.");
+            return 1;
+        }
+        Console.WriteLine($"  virtual XInput slot: {slot}");
+
+        var active = new HMGamepadState
+        {
+            Axes = HMGamepadStateHelpers.StandardAxes(profile,
+                leftStickX: 1.0f, leftStickY: 0.0f,
+                rightStickX: 1.0f, rightStickY: 0.0f,
+                leftTrigger: 1.0f, rightTrigger: 1.0f),
+            Buttons = HMButton.A | HMButton.B | HMButton.Start,
+            Hat = HMHat.East,
+        };
+
+        WaitForActive(ctrl, in active, slot, "baseline source input reaches XInput", timeoutMs: 3000);
+
+        ctrl.Neutralized = true;
+        Thread.Sleep(80);
+        XInputGetState((uint)slot, out var afterSet);
+        Check("setting Neutralized immediately releases current input",
+            IsNeutral(in afterSet), FormatState(in afterSet));
+
+        AssertNeutralStable(ctrl, in active, slot,
+            "Neutralized=true suppresses continued active source input", durationMs: 1500);
+
+        ctrl.Neutralized = false;
+        WaitForActive(ctrl, in active, slot,
+            "Neutralized=false restores input without reconnect", timeoutMs: 3000);
+
+        ctrl.Neutralized = true;
+        AssertNeutralStable(ctrl, in active, slot,
+            "second neutralize remains stable on same slot", durationMs: 1000);
+
+        ctrl.Neutralized = false;
+        WaitForActive(ctrl, in active, slot,
+            "second unneutralize restores input on same slot", timeoutMs: 3000);
+
+        Console.WriteLine($"\n=== {s_total - s_failures}/{s_total} PASS ===");
+        return s_failures == 0 ? 0 : 1;
+    }
+}

--- a/test/probes/neutral_xinput_check/app.manifest
+++ b/test/probes/neutral_xinput_check/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/test/probes/real_passthrough_neutral_check/Program.cs
+++ b/test/probes/real_passthrough_neutral_check/Program.cs
@@ -1,0 +1,531 @@
+// Real-input passthrough neutralization check.
+//
+// Reads a real controller through XInput, mirrors that state into virtual
+// HIDMaestro controllers, and verifies the virtual HID input report:
+//   - Neutralized=false: virtual axes/buttons match the sampled real state.
+//   - Neutralized=true: virtual stays neutral while the real input is still
+//     being submitted.
+//
+// Profiles covered: DS4 USB, DualSense USB, Switch Pro.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using HIDMaestro;
+using HIDMaestro.Internal;
+
+internal sealed class Program
+{
+    private const uint ERROR_SUCCESS = 0;
+    private static int s_total;
+    private static int s_failures;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_GAMEPAD
+    {
+        public ushort wButtons;
+        public byte bLeftTrigger;
+        public byte bRightTrigger;
+        public short sThumbLX;
+        public short sThumbLY;
+        public short sThumbRX;
+        public short sThumbRY;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XINPUT_STATE
+    {
+        public uint dwPacketNumber;
+        public XINPUT_GAMEPAD Gamepad;
+    }
+
+    [DllImport("xinput1_4.dll")]
+    private static extern uint XInputGetState(uint dwUserIndex, out XINPUT_STATE pState);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct HIDD_ATTRIBUTES
+    {
+        public int Size;
+        public ushort VendorID;
+        public ushort ProductID;
+        public ushort VersionNumber;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SP_DEVICE_INTERFACE_DATA
+    {
+        public int cbSize;
+        public Guid InterfaceClassGuid;
+        public uint Flags;
+        public IntPtr Reserved;
+    }
+
+    [DllImport("hid.dll", SetLastError = true)]
+    private static extern void HidD_GetHidGuid(out Guid guid);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    private static extern bool HidD_GetAttributes(IntPtr h, ref HIDD_ATTRIBUTES attr);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    private static extern bool HidD_GetInputReport(IntPtr h, byte[] buf, int len);
+
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr SetupDiGetClassDevsW(ref Guid classGuid, IntPtr enumerator, IntPtr hwnd, uint flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiEnumDeviceInterfaces(IntPtr h, IntPtr devInfoData, ref Guid classGuid, uint memberIndex, ref SP_DEVICE_INTERFACE_DATA data);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool SetupDiGetDeviceInterfaceDetailW(IntPtr h, ref SP_DEVICE_INTERFACE_DATA data, IntPtr detail, uint detailSize, out uint required, IntPtr devInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool SetupDiGetDeviceInterfaceDetailW(IntPtr h, ref SP_DEVICE_INTERFACE_DATA data, IntPtr detail, uint detailSize, IntPtr required, IntPtr devInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr h);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateFileW(string fn, uint access, uint share, IntPtr sec, uint creation, uint flags, IntPtr template);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr h);
+
+    private const uint DIGCF_PRESENT = 0x02;
+    private const uint DIGCF_DEVICEINTERFACE = 0x10;
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint GENERIC_WRITE = 0x40000000;
+    private const uint FILE_SHARE_READ = 0x01;
+    private const uint FILE_SHARE_WRITE = 0x02;
+    private const uint OPEN_EXISTING = 3;
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+
+    private sealed record RealSample(int Slot, XINPUT_STATE State, HMGamepadState HMState);
+
+    private static void Check(string label, bool ok, string detail = "")
+    {
+        s_total++;
+        if (!ok) s_failures++;
+        Console.WriteLine($"  [{(ok ? "PASS" : "FAIL")}] {label}{(detail.Length > 0 ? "  " + detail : "")}");
+    }
+
+    private static string FormatReal(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return $"pkt={s.dwPacketNumber} btn=0x{g.wButtons:X4} LT={g.bLeftTrigger} RT={g.bRightTrigger} " +
+               $"LX={g.sThumbLX} LY={g.sThumbLY} RX={g.sThumbRX} RY={g.sThumbRY}";
+    }
+
+    private static float Axis(short value) => ((int)value + 32768) / 65535f;
+    private static float Trigger(byte value) => value / 255f;
+
+    private static bool RealIsActive(in XINPUT_STATE s)
+    {
+        var g = s.Gamepad;
+        return g.wButtons != 0
+            || g.bLeftTrigger > 8
+            || g.bRightTrigger > 8
+            || Math.Abs((int)g.sThumbLX) > 4000
+            || Math.Abs((int)g.sThumbLY) > 4000
+            || Math.Abs((int)g.sThumbRX) > 4000
+            || Math.Abs((int)g.sThumbRY) > 4000;
+    }
+
+    private static HMButton ConvertButtons(ushort x)
+    {
+        HMButton b = HMButton.None;
+        if ((x & 0x1000) != 0) b |= HMButton.A;
+        if ((x & 0x2000) != 0) b |= HMButton.B;
+        if ((x & 0x4000) != 0) b |= HMButton.X;
+        if ((x & 0x8000) != 0) b |= HMButton.Y;
+        if ((x & 0x0100) != 0) b |= HMButton.LeftBumper;
+        if ((x & 0x0200) != 0) b |= HMButton.RightBumper;
+        if ((x & 0x0020) != 0) b |= HMButton.Back;
+        if ((x & 0x0010) != 0) b |= HMButton.Start;
+        if ((x & 0x0040) != 0) b |= HMButton.LeftStick;
+        if ((x & 0x0080) != 0) b |= HMButton.RightStick;
+        if ((x & 0x0400) != 0) b |= HMButton.Guide;
+        return b;
+    }
+
+    private static HMHat ConvertHat(ushort x)
+    {
+        bool up = (x & 0x0001) != 0, down = (x & 0x0002) != 0;
+        bool left = (x & 0x0004) != 0, right = (x & 0x0008) != 0;
+        if (up && right) return HMHat.NorthEast;
+        if (down && right) return HMHat.SouthEast;
+        if (down && left) return HMHat.SouthWest;
+        if (up && left) return HMHat.NorthWest;
+        if (up) return HMHat.North;
+        if (right) return HMHat.East;
+        if (down) return HMHat.South;
+        if (left) return HMHat.West;
+        return HMHat.None;
+    }
+
+    private static HMGamepadState ConvertRealToHM(HMProfile targetProfile, in XINPUT_STATE real)
+    {
+        var g = real.Gamepad;
+        return new HMGamepadState
+        {
+            Axes = HMGamepadStateHelpers.StandardAxes(targetProfile,
+                leftStickX: Axis(g.sThumbLX),
+                leftStickY: Axis(g.sThumbLY),
+                rightStickX: Axis(g.sThumbRX),
+                rightStickY: Axis(g.sThumbRY),
+                leftTrigger: Trigger(g.bLeftTrigger),
+                rightTrigger: Trigger(g.bRightTrigger)),
+            Buttons = ConvertButtons(g.wButtons),
+            Hat = ConvertHat(g.wButtons),
+        };
+    }
+
+    private static RealSample WaitForRealActive(HMProfile targetProfile, int timeoutMs)
+    {
+        Console.WriteLine();
+        Console.WriteLine("  ===============================================================");
+        Console.WriteLine("  ESPERANDO INPUT DO CONTROLE REAL");
+        Console.WriteLine("  Mexa um analógico ou segure qualquer botão agora.");
+        Console.WriteLine("  O teste continua automaticamente quando detectar input ativo.");
+        Console.WriteLine("  ===============================================================");
+        Console.WriteLine();
+        try { Console.Beep(880, 180); Console.Beep(660, 180); } catch { }
+        var sw = Stopwatch.StartNew();
+        XINPUT_STATE last = default;
+        int lastSlot = -1;
+        long nextStatusMs = 0;
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            for (int slot = 0; slot < 4; slot++)
+            {
+                if (XInputGetState((uint)slot, out var state) != ERROR_SUCCESS) continue;
+                last = state;
+                lastSlot = slot;
+                if (!RealIsActive(in state)) continue;
+                Console.WriteLine($"  Input real detectado no slot {slot}: {FormatReal(in state)}");
+                return new RealSample(slot, state, ConvertRealToHM(targetProfile, in state));
+            }
+            if (sw.ElapsedMilliseconds >= nextStatusMs)
+            {
+                int remaining = Math.Max(0, (timeoutMs - (int)sw.ElapsedMilliseconds) / 1000);
+                Console.WriteLine($"  ...ainda esperando input real ({remaining}s restantes). Último slot={lastSlot}, {FormatReal(in last)}");
+                nextStatusMs = sw.ElapsedMilliseconds + 1000;
+            }
+            Thread.Sleep(50);
+        }
+        throw new InvalidOperationException($"No active real XInput input observed within {timeoutMs} ms. Last slot={lastSlot}, state={FormatReal(in last)}");
+    }
+
+    private static string? FindHidDevicePath(ushort vid, ushort pid)
+    {
+        HidD_GetHidGuid(out Guid hidGuid);
+        IntPtr h = SetupDiGetClassDevsW(ref hidGuid, IntPtr.Zero, IntPtr.Zero, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (h == INVALID_HANDLE_VALUE) return null;
+        try
+        {
+            for (uint i = 0; ; i++)
+            {
+                var data = new SP_DEVICE_INTERFACE_DATA { cbSize = Marshal.SizeOf<SP_DEVICE_INTERFACE_DATA>() };
+                if (!SetupDiEnumDeviceInterfaces(h, IntPtr.Zero, ref hidGuid, i, ref data)) break;
+                SetupDiGetDeviceInterfaceDetailW(h, ref data, IntPtr.Zero, 0, out uint required, IntPtr.Zero);
+                IntPtr buf = Marshal.AllocHGlobal((int)required);
+                try
+                {
+                    Marshal.WriteInt32(buf, IntPtr.Size == 8 ? 8 : 6);
+                    if (!SetupDiGetDeviceInterfaceDetailW(h, ref data, buf, required, IntPtr.Zero, IntPtr.Zero)) continue;
+                    string path = Marshal.PtrToStringUni(IntPtr.Add(buf, 4))!;
+                    IntPtr fh = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+                    if (fh == INVALID_HANDLE_VALUE) continue;
+                    try
+                    {
+                        var attr = new HIDD_ATTRIBUTES { Size = Marshal.SizeOf<HIDD_ATTRIBUTES>() };
+                        if (HidD_GetAttributes(fh, ref attr) && attr.VendorID == vid && attr.ProductID == pid)
+                            return path;
+                    }
+                    finally { CloseHandle(fh); }
+                }
+                finally { Marshal.FreeHGlobal(buf); }
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(h); }
+        return null;
+    }
+
+    private static byte[]? GetCurrentInputReport(string path, int reportLen, byte reportId)
+    {
+        IntPtr fh = CreateFileW(path, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+        if (fh == INVALID_HANDLE_VALUE) return null;
+        try
+        {
+            byte[] buf = new byte[reportLen];
+            buf[0] = reportId;
+            return HidD_GetInputReport(fh, buf, buf.Length) ? buf : null;
+        }
+        finally { CloseHandle(fh); }
+    }
+
+    private static int ReadField(byte[] report, HidReportBuilder.InputField field, byte reportId)
+    {
+        int idOffset = reportId != 0 ? 8 : 0;
+        int bit = field.BitOffset + idOffset;
+        long value = 0;
+        for (int i = 0; i < field.BitSize; i++)
+        {
+            int b = (bit + i) / 8;
+            int sh = (bit + i) % 8;
+            if ((report[b] & (1 << sh)) != 0) value |= 1L << i;
+        }
+        return (int)value;
+    }
+
+    private static int ExpectedAxisRaw(HidReportBuilder.InputField field, float normalized)
+    {
+        double n = Math.Clamp(normalized, 0f, 1f);
+        return (int)Math.Round(field.LogicalMin + n * (field.LogicalMax - field.LogicalMin));
+    }
+
+    private static bool AxisMatches(byte[] report, byte reportId, HidReportBuilder.InputField? field, float expected, out string detail)
+    {
+        detail = "";
+        if (field == null) return true;
+        int got = ReadField(report, field, reportId);
+        int want = ExpectedAxisRaw(field, expected);
+        int tolerance = Math.Max(3, (field.LogicalMax - field.LogicalMin) / 128);
+        bool ok = Math.Abs(got - want) <= tolerance;
+        detail = $"usage=0x{field.UsagePage:X2}:0x{field.Usage:X2} got={got} want~={want} tol={tolerance}";
+        return ok;
+    }
+
+    private static bool FieldIsNeutral(byte[] report, byte reportId, HidReportBuilder.InputField? field, bool released, out string detail)
+    {
+        detail = "";
+        if (field == null) return true;
+        int got = ReadField(report, field, reportId);
+        int want = released ? field.LogicalMin : ExpectedAxisRaw(field, 0.5f);
+        int tolerance = Math.Max(3, (field.LogicalMax - field.LogicalMin) / 128);
+        bool ok = Math.Abs(got - want) <= tolerance;
+        detail = $"usage=0x{field.UsagePage:X2}:0x{field.Usage:X2} got={got} neutral~={want} tol={tolerance}";
+        return ok;
+    }
+
+    private static bool ButtonMatches(byte[] report, byte reportId, HidReportBuilder rb, HMButton expected, out string detail)
+    {
+        var problems = new List<string>();
+        for (int bit = 0; bit < 13; bit++)
+        {
+            int desc = rb.ButtonMap != null && bit < rb.ButtonMap.Length ? rb.ButtonMap[bit] : bit;
+            if ((uint)desc >= (uint)rb.Buttons.Count) continue;
+            int got = ReadField(report, rb.Buttons[desc], reportId);
+            int want = (((uint)expected & (1u << bit)) != 0) ? 1 : 0;
+            if ((got != 0 ? 1 : 0) != want)
+                problems.Add($"HMButton[{bit}] desc={desc} got={got} want={want}");
+        }
+        detail = string.Join("; ", problems);
+        return problems.Count == 0;
+    }
+
+    private static bool ButtonsNeutral(byte[] report, byte reportId, HidReportBuilder rb, out string detail)
+    {
+        var pressed = new List<string>();
+        for (int i = 0; i < rb.Buttons.Count; i++)
+        {
+            int got = ReadField(report, rb.Buttons[i], reportId);
+            if (got != 0) pressed.Add($"descButton[{i}]={got}");
+        }
+        detail = string.Join("; ", pressed);
+        return pressed.Count == 0;
+    }
+
+    private static bool HatNeutral(byte[] report, byte reportId, HidReportBuilder rb, out string detail)
+    {
+        detail = "";
+        if (rb.HatSwitch == null) return true;
+        int got = ReadField(report, rb.HatSwitch, reportId);
+        int neutral = rb.HatSwitch.LogicalMin == 0 ? rb.HatSwitch.LogicalMax + 1 : 0;
+        bool ok = got == neutral;
+        detail = $"hat got={got} neutral={neutral}";
+        return ok;
+    }
+
+    private static bool MirrorMatchesReal(HMProfile profile, HidReportBuilder rb, byte[] report, RealSample sample, out string detail)
+    {
+        var axes = sample.HMState.Axes!;
+        bool ok = true;
+        var details = new List<string>();
+        void Axis(string name, HidReportBuilder.InputField? field, HMAxis axis)
+        {
+            if (field == null || axis == HMAxis.None) return;
+            float expected = axes.TryGetValue(axis, out var v) ? v : (field.LogicalMin < 0 ? 0.5f : 0f);
+            if (!AxisMatches(report, rb.InputReportId, field, expected, out string d))
+            {
+                ok = false;
+                details.Add($"{name}: {d}");
+            }
+        }
+
+        var sticks = profile.Sticks;
+        var triggers = profile.Triggers;
+        Axis("LSX", rb.LeftStickX, sticks.Count > 0 ? sticks[0].XAxis : HMAxis.None);
+        Axis("LSY", rb.LeftStickY, sticks.Count > 0 ? sticks[0].YAxis : HMAxis.None);
+        Axis("RSX", rb.RightStickX, sticks.Count > 1 ? sticks[1].XAxis : HMAxis.None);
+        Axis("RSY", rb.RightStickY, sticks.Count > 1 ? sticks[1].YAxis : HMAxis.None);
+        Axis("LT", rb.LeftTrigger, triggers.Count > 0 ? triggers[0].Axis : HMAxis.None);
+        Axis("RT", rb.RightTrigger, triggers.Count > 1 ? triggers[1].Axis : HMAxis.None);
+
+        // Axis fidelity is the key passthrough invariant here. Button maps are
+        // profile-specific (Sony L2/R2 can be derived from analog triggers), so
+        // keep button comparison best-effort and only assert it when the source
+        // has explicit digital buttons pressed.
+        if (sample.HMState.Buttons != HMButton.None
+            && !ButtonMatches(report, rb.InputReportId, rb, sample.HMState.Buttons, out string btnDetail))
+        {
+            ok = false;
+            details.Add("buttons: " + btnDetail);
+        }
+
+        detail = string.Join(" | ", details);
+        return ok;
+    }
+
+    private static bool VerifyMirrorsReal(HMProfile profile, HidReportBuilder rb, byte[] report, RealSample sample, string label)
+    {
+        bool ok = MirrorMatchesReal(profile, rb, report, sample, out string detail);
+        var real = sample.State;
+        Check(label, ok, ok ? FormatReal(in real) : detail);
+        return ok;
+    }
+
+    private static bool VerifyNeutral(HidReportBuilder rb, byte[] report, string label)
+    {
+        bool ok = true;
+        var details = new List<string>();
+        void NeutralAxis(string name, HidReportBuilder.InputField? field, bool released)
+        {
+            if (!FieldIsNeutral(report, rb.InputReportId, field, released, out string d))
+            {
+                ok = false;
+                details.Add($"{name}: {d}");
+            }
+        }
+
+        NeutralAxis("LSX", rb.LeftStickX, released: false);
+        NeutralAxis("LSY", rb.LeftStickY, released: false);
+        NeutralAxis("RSX", rb.RightStickX, released: false);
+        NeutralAxis("RSY", rb.RightStickY, released: false);
+        NeutralAxis("LT", rb.LeftTrigger, released: true);
+        NeutralAxis("RT", rb.RightTrigger, released: true);
+        if (!ButtonsNeutral(report, rb.InputReportId, rb, out string btnDetail))
+        {
+            ok = false;
+            details.Add("buttons: " + btnDetail);
+        }
+        if (!HatNeutral(report, rb.InputReportId, rb, out string hatDetail))
+        {
+            ok = false;
+            details.Add(hatDetail);
+        }
+
+        Check(label, ok, ok ? "wire report is neutral" : string.Join(" | ", details));
+        return ok;
+    }
+
+    private static bool WaitForMirror(HMController ctrl, HMProfile profile, HidReportBuilder rb,
+        string path, int reportSize, RealSample sample, string label, int timeoutMs = 1500)
+    {
+        var sw = Stopwatch.StartNew();
+        byte[]? last = null;
+        var state = sample.HMState;
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            ctrl.SubmitState(in state);
+            Thread.Sleep(35);
+            last = GetCurrentInputReport(path, reportSize, rb.InputReportId);
+            if (last == null) continue;
+
+            if (MirrorMatchesReal(profile, rb, last, sample, out _))
+                return VerifyMirrorsReal(profile, rb, last, sample, label);
+        }
+
+        if (last == null)
+        {
+            Check(label, false, "GetInputReport returned null until timeout");
+            return false;
+        }
+        return VerifyMirrorsReal(profile, rb, last, sample, label);
+    }
+
+    private static void TestProfile(HMContext ctx, string profileId)
+    {
+        var profile = ctx.GetProfile(profileId) ?? throw new Exception($"missing profile: {profileId}");
+        Console.WriteLine($"\n=== Profile {profile.Id} ({profile.Name}) VID={profile.VendorId:X4} PID={profile.ProductId:X4} ===");
+
+        var descriptor = profile.GetDescriptorBytes() ?? throw new Exception($"profile {profile.Id} has no descriptor");
+        var rb = HidReportBuilder.Parse(descriptor, profile.AxisMap);
+        rb.ButtonMap = profile.ButtonMap;
+        if (profile.Layout != null) rb.ApplyLayoutSemantics(profile.Layout);
+        RealSample sample = WaitForRealActive(profile, timeoutMs: 120_000);
+        var realStateForLog = sample.State;
+        Console.WriteLine($"  real source slot={sample.Slot}: {FormatReal(in realStateForLog)}");
+
+        using var ctrl = ctx.CreateController(profile);
+        Thread.Sleep(800);
+        string? path = FindHidDevicePath(profile.VendorId, profile.ProductId);
+        Check($"{profile.Id}: virtual HID path resolved", path != null, path ?? "");
+        if (path == null) return;
+
+        ctrl.Neutralized = false;
+        var sampleState = sample.HMState;
+        ctrl.SubmitState(in sampleState);
+        Thread.Sleep(60);
+        int reportSize = profile.InputReportSize > 0 ? profile.InputReportSize : rb.InputReportByteSize;
+        byte[]? report = GetCurrentInputReport(path, reportSize, rb.InputReportId);
+        Check($"{profile.Id}: GetInputReport while neutral off", report != null);
+        if (report != null)
+            VerifyMirrorsReal(profile, rb, report, sample, $"{profile.Id}: neutral off mirrors sampled real input");
+
+        ctrl.Neutralized = true;
+        // Keep feeding the active real sample while neutralized.
+        for (int i = 0; i < 5; i++)
+        {
+            ctrl.SubmitState(in sampleState);
+            Thread.Sleep(25);
+        }
+        report = GetCurrentInputReport(path, reportSize, rb.InputReportId);
+        Check($"{profile.Id}: GetInputReport while neutral on", report != null);
+        if (report != null)
+            VerifyNeutral(rb, report, $"{profile.Id}: neutral on suppresses real input");
+
+        ctrl.Neutralized = false;
+        WaitForMirror(ctrl, profile, rb, path, reportSize, sample,
+            $"{profile.Id}: neutral off restores real input");
+    }
+
+    public static int Main(string[] args)
+    {
+        Console.WriteLine("=== HIDMaestro real-input passthrough neutral regression ===");
+        Console.WriteLine("Move/press your real XInput gamepad when prompted so the test has non-neutral source data.");
+
+        string[] profiles = args.Length > 0
+            ? args
+            : new[] { "dualshock-4-v2", "dualsense", "switch-pro" };
+
+        try { HMContext.RemoveAllVirtualControllers(); } catch { }
+        Thread.Sleep(500);
+
+        using var ctx = new HMContext();
+        ctx.LoadDefaultProfiles();
+        Console.Write("Installing driver... ");
+        ctx.InstallDriver();
+        Console.WriteLine("OK");
+
+        foreach (string profile in profiles)
+        {
+            TestProfile(ctx, profile);
+        }
+
+        Console.WriteLine($"\n=== {s_total - s_failures}/{s_total} PASS ===");
+        return s_failures == 0 ? 0 : 1;
+    }
+}

--- a/test/probes/real_passthrough_neutral_check/RealPassthroughNeutralCheck.csproj
+++ b/test/probes/real_passthrough_neutral_check/RealPassthroughNeutralCheck.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PlatformTarget>x64</PlatformTarget>
+    <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk\HIDMaestro.Core\HIDMaestro.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/probes/real_passthrough_neutral_check/app.manifest
+++ b/test/probes/real_passthrough_neutral_check/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/test/regression/neutral_regression.ps1
+++ b/test/regression/neutral_regression.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+  Build-and-run regression battery for HIDMaestro's neutral-input override.
+
+.DESCRIPTION
+  Runs three elevated probes:
+
+    1. neutral_xinput_check
+       Direct SDK path: HMController.Neutralized suppresses active input while
+       the virtual stays connected through XInput.
+
+    2. neutral_cli_check
+       User-facing CLI path: HIDMaestroTest.exe emulate accepts
+       "neutral on/off/toggle" over stdin, acknowledges each command, and the
+       same XInput slot stays connected but idle while neutral is on.
+
+    3. browser_neutral_check
+       Browser Gamepad API path: creates a virtual DS4, samples it through
+       navigator.getGamepads(), and verifies neutral-on is stable across
+       multiple samples. Also documents the expected active test pattern after
+       neutral off.
+
+  Exit code 0 if all probes pass.
+#>
+[CmdletBinding()]
+param(
+    [string]$DotnetPath = 'D:\CODING\SDKs\dotnet',
+    [string]$EwdkPath = 'D:\CODING\SDKs\EWDK',
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = if ($PSScriptRoot) {
+    $PSScriptRoot
+} elseif ($MyInvocation.MyCommand.Path) {
+    Split-Path -Parent $MyInvocation.MyCommand.Path
+} else {
+    $PWD.Path
+}
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $scriptDir '..\..'))
+$tfm = 'net10.0-windows10.0.26100.0'
+$dotnet = Join-Path $DotnetPath 'dotnet.exe'
+if (-not (Test-Path $dotnet)) {
+    $dotnet = (Get-Command dotnet -ErrorAction Stop).Source
+}
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Error "This script must run elevated. Start an Administrator PowerShell or run it through UAC."
+    exit 2
+}
+
+function Invoke-Step {
+    param(
+        [string]$Name,
+        [scriptblock]$Body
+    )
+    Write-Host ""
+    Write-Host "=== $Name ===" -ForegroundColor Cyan
+    & $Body
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Name failed with exit code $LASTEXITCODE"
+    }
+}
+
+if (-not $SkipBuild) {
+    Invoke-Step 'Build driver + SDK payload' {
+        & pwsh -NoProfile -ExecutionPolicy Bypass -File (Join-Path $repoRoot 'build.ps1')
+    }
+
+    $wdkBin = ($EwdkPath -replace '\\','/') + '/Program Files/Windows Kits/10/bin/10.0.28000.0/'
+    $buildDir = ($repoRoot -replace '\\','/') + '/build/'
+
+    Invoke-Step 'Build SDK win-x64 reference' {
+        & $dotnet build (Join-Path $repoRoot 'sdk\HIDMaestro.Core\HIDMaestro.Core.csproj') `
+            -c Release -r win-x64 -nologo -v minimal `
+            "/p:HMWdkBin=$wdkBin" "/p:HMBuildDir=$buildDir"
+    }
+
+    Invoke-Step 'Build HIDMaestroTest CLI' {
+        & $dotnet build (Join-Path $repoRoot 'test\HIDMaestroTest.csproj') `
+            -c Release -nologo -v minimal --no-dependencies
+    }
+
+    Invoke-Step 'Build neutral_xinput_check probe' {
+        & $dotnet build (Join-Path $repoRoot 'test\probes\neutral_xinput_check\NeutralXInputCheck.csproj') `
+            -c Release -r win-x64 -nologo -v minimal --no-dependencies
+    }
+
+    Invoke-Step 'Build neutral_cli_check probe' {
+        & $dotnet build (Join-Path $repoRoot 'test\probes\neutral_cli_check\NeutralCliCheck.csproj') `
+            -c Release -r win-x64 -nologo -v minimal
+    }
+
+    Invoke-Step 'Build browser_neutral_check probe' {
+        & $dotnet build (Join-Path $repoRoot 'test\probes\browser_neutral_check\BrowserNeutralCheck.csproj') `
+            -c Release -r win-x64 -nologo -v minimal
+    }
+}
+
+$directProbe = Join-Path $repoRoot "test\probes\neutral_xinput_check\bin\Release\$tfm\win-x64\NeutralXInputCheck.exe"
+$cliProbe = Join-Path $repoRoot "test\probes\neutral_cli_check\bin\Release\$tfm\win-x64\NeutralCliCheck.exe"
+$browserProbe = Join-Path $repoRoot "test\probes\browser_neutral_check\bin\Release\$tfm\win-x64\BrowserNeutralCheck.exe"
+
+Invoke-Step 'Run direct SDK neutral probe' {
+    & $directProbe
+}
+
+Invoke-Step 'Run CLI neutral probe' {
+    & $cliProbe
+}
+
+Invoke-Step 'Run Browser Gamepad API neutral probe' {
+    & $browserProbe
+}
+
+Write-Host ""
+Write-Host "=== NEUTRAL REGRESSION BATTERY: ALL PASS ===" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary
- Adds a live `HMController.Neutralized` override that keeps virtual controllers connected while publishing profile-aware neutral input.
- Exposes neutral mode in the test CLI and adds regression probes for SDK, CLI, XInput, real passthrough, and browser Gamepad API coverage.
- Preserves the latest real submitted state so disabling neutral mode resumes passthrough without requiring a reconnect.

## Test plan
- Built `sdk/HIDMaestro.Core/HIDMaestro.Core.csproj` in Release using existing driver artifacts.
- Exercised neutral behavior during local browser/CLI/manual diagnostics.

Made with [Cursor](https://cursor.com)